### PR TITLE
pith doesn't ignore emacs backup files

### DIFF
--- a/lib/pith/project.rb
+++ b/lib/pith/project.rb
@@ -8,7 +8,7 @@ module Pith
 
   class Project
 
-    DEFAULT_IGNORE_PATTERNS = ["_*", ".git", ".svn"].freeze
+    DEFAULT_IGNORE_PATTERNS = ["_*", ".git", ".svn", "*~"].freeze
 
     def initialize(attributes = {})
       @ignore_patterns = DEFAULT_IGNORE_PATTERNS.dup


### PR DESCRIPTION
When emacs edits a file, file.txt, it leaves behind a backup file, file.txt~. Pith ignores .git, .svn and files beginning with "_", but not files ending in "~", and so these backup files get copied to the _out directory (for instance, index.html.haml~).
