### PR TITLE
adding requirement for set

### DIFF
--- a/lib/pith/config.rb
+++ b/lib/pith/config.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Pith
 
   class Config


### PR DESCRIPTION
When trying to run "pith build", I was getting this error with version 0.3.1:

<pre>
$ pith build                                                                                          (21:43:28)
/Library/Ruby/Gems/1.8/gems/pith-0.3.1/lib/pith/config.rb:5: undefined method `to_set' for #<Array:0x1012bbc98> (NoMethodError)
    from /Library/Ruby/Site/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
    from /Library/Ruby/Site/1.8/rubygems/custom_require.rb:36:in `require'
    from /Library/Ruby/Gems/1.8/gems/pith-0.3.1/lib/pith/config_provider.rb:1
    from /Library/Ruby/Site/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
    from /Library/Ruby/Site/1.8/rubygems/custom_require.rb:36:in `require'
    from /Library/Ruby/Gems/1.8/gems/pith-0.3.1/lib/pith/project.rb:2
    from /Library/Ruby/Site/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
    from /Library/Ruby/Site/1.8/rubygems/custom_require.rb:36:in `require'
    from /Library/Ruby/Gems/1.8/gems/pith-0.3.1/bin/pith:12
    from /usr/bin/pith:19:in `load'
    from /usr/bin/pith:19
</pre>


So by adding a requirement for th set module to config.rb, the error goes away and pith works as expected.
