### PR TITLE
"Enhancements" to link method

### DIFF
--- a/features/link_attributes.feature
+++ b/features/link_attributes.feature
@@ -12,10 +12,7 @@ Scenario: link with class attribute
   And input file "page.html" exists
 
   When I build the site
-  Then output file "index.html" should contain
-    """
-    <a class="active" href="page.html">Page</a>
-    """
+  Then output file "index.html" should contain /<a [class="active", href="page.html"]/
 
 Scenario: link with title attribute
 
@@ -26,10 +23,7 @@ Scenario: link with title attribute
   And input file "page.html" exists
 
   When I build the site
-  Then output file "index.html" should contain
-    """
-    <a title="click me" href="page.html">Page</a>
-    """
+  Then output file "index.html" should contain /<a [title="click me", href="page.html"]/
 
 Scenario: link with title and class attributes
 

--- a/features/link_attributes.feature
+++ b/features/link_attributes.feature
@@ -1,0 +1,43 @@
+Feature: link method with attributes
+
+  I want to be able to pass arguments to the link method
+  So that additional attributes are generated
+
+Scenario: link with class attribute
+
+  Given input file "index.html.haml" contains
+    """
+    = link("page.html", "Page", :class => 'active')
+    """
+  And input file "page.html" exists
+
+  When I build the site
+  Then output file "index.html" should contain
+    """
+    <a class="active" href="page.html">Page</a>
+    """
+
+Scenario: link with title attribute
+
+  Given input file "index.html.haml" contains
+    """
+    = link("page.html", "Page", :title => 'click me')
+    """
+  And input file "page.html" exists
+
+  When I build the site
+  Then output file "index.html" should contain
+    """
+    <a title="click me" href="page.html">Page</a>
+    """
+
+Scenario: link with title and class attributes
+
+  Given input file "index.html.haml" contains
+    """
+    = link("page.html", "Page", :title => 'click me', :class => 'active')
+    """
+  And input file "page.html" exists
+
+  When I build the site
+  Then output file "index.html" should contain /<a [title="click me", class="active", href="page.html"]/

--- a/features/relative_linking.feature
+++ b/features/relative_linking.feature
@@ -31,6 +31,32 @@ Scenario: link from a sub-directory to a root-level page
     <a href="../help.html">Help</a>
     """
 
+Scenario: link to an absolute url
+
+  Given input file "index.html.haml" contains
+    """
+    = link("http://example.com", "Go to example.com")
+    """
+
+  When I build the site
+  Then output file "index.html" should contain
+    """
+    <a href="http://example.com">Go to example.com</a>
+    """
+
+Scenario: link to a (secure) absolute url
+
+  Given input file "index.html.haml" contains
+    """
+    = link("https://example.com", "Securely go to example.com")
+    """
+
+  When I build the site
+  Then output file "index.html" should contain
+    """
+    <a href="https://example.com">Securely go to example.com</a>
+    """
+
 Scenario: link to an image
 
   Given input file "subdir/page.html.haml" contains

--- a/lib/pith/render_context.rb
+++ b/lib/pith/render_context.rb
@@ -32,9 +32,9 @@ module Pith
 
     def render(input, locals = {}, &block)
       with_input(input) do
-        result = input.render(self, locals, &block)
+        result     = input.render(self, locals, &block)
         layout_ref = input.meta["layout"]
-        result = render_ref(layout_ref) { result } if layout_ref
+        result     = render_ref(layout_ref) { result } if layout_ref
         result
       end
     end
@@ -65,8 +65,15 @@ module Pith
       relative_url_to(resolve_reference(target_ref))
     end
 
-    def link(target_ref, label = nil)
-      target_path = resolve_reference(target_ref)
+    def link(target_ref, label = nil, attrs={})
+
+      if absolute_url? target_ref
+        attrs['href'] = target_ref
+      else
+        target_path = resolve_reference(target_ref)
+        attrs['href'] = relative_url_to(target_path)
+      end
+
       label ||= begin
         target_input = input(target_path)
         output.record_dependency_on(target_input)
@@ -74,11 +81,30 @@ module Pith
       rescue ReferenceError
         "???"
       end
-      url = relative_url_to(target_path)
-      %{<a href="#{url}">#{label}</a>}
+      
+      # Loop through attrs hash, flatten the key, value
+      # pairs for appending to the dom element/link
+      attrs_flatten = attrs.each_pair.collect do |key, value|
+                        %Q{#{key}="#{value}"}
+                      end.join(' ')
+      
+      "<a #{attrs_flatten}>#{label}</a>"
     end
 
     private
+    
+    def absolute_url?(ref)
+      
+      # Need host and absolute as the ruby URI library will say that 
+      # http:/example.com is absolute, but don't have a domain
+      
+      begin
+        url = URI.parse(ref.to_s)
+        url.absolute? and !url.host.nil?
+      rescue URI::InvalidURIError
+        false
+      end
+    end
 
     def resolve_reference(ref)
       if ref.kind_of?(Pith::Input)


### PR DESCRIPTION
Minor improvement to link method, can pass optional attributes

```
link(page.html", "Page", :title => 'click me', :class => 'active')
```

  becomes...

```
<a title="click me" class="active" href="page.html />
```

Also, fixed an issue with the link method, and absolute urls. Previously link stripped the first slash after the protocol definition

```
http://example.com → http:/example.com
```
