### PR TITLE
Adjust ignore method to accept/define ignore pattern as multiple arguments

### DIFF
--- a/lib/pith/config.rb
+++ b/lib/pith/config.rb
@@ -16,8 +16,8 @@ module Pith
 
     attr_reader :ignore_patterns
 
-    def ignore(pattern)
-      ignore_patterns << pattern
+    def ignore(*pattern)
+      pattern.flatten.each {|p| ignore_patterns << p }
     end
 
     attr_reader :helper_module

--- a/spec/pith/config_spec.rb
+++ b/spec/pith/config_spec.rb
@@ -23,7 +23,19 @@ describe Pith::Config do
 
     it "adds to ignore_patterns" do
       config.ignore("foo")
-      config.ignore_patterns
+      config.ignore_patterns.should be_member('foo')
+    end
+
+    it "adds multiple patterns to ignore_patterns (when passed multiple arguments)" do
+      config.ignore("foo", "bar")
+      config.ignore_patterns.should be_member('foo')
+      config.ignore_patterns.should be_member('bar')
+    end
+
+    it "adds multiple patterns to ignore_patterns (when passed an array)" do
+      config.ignore(["foo", "bar"])
+      config.ignore_patterns.should be_member('foo')
+      config.ignore_patterns.should be_member('bar')
     end
 
   end


### PR DESCRIPTION
The ignore method (in config) only takes one argument, so need to call it multiple times (if want to define more than one ignore pattern)

```
ignore('foo')
ignore('bar')
```

This patch allows the ignore pattern to be define through multiple parameters, or as an array

```
ignore('foo','bar')
```

or alternatively

```
ignore(['foo','bar'])
```
