### PR TITLE
Fixes to meta 'published' and 'updated' methods, on ruby 2.0.0

### DIFF
--- a/lib/pith/plugins/publication/input.rb
+++ b/lib/pith/plugins/publication/input.rb
@@ -30,7 +30,9 @@ module Pith
           return date_string if date_string.instance_of? Time
           return date_string.to_time if date_string.respond_to?('to_time')
 
-          Time.parse(date_string)
+          # cast to a string prior to casting
+          # as ruby 1.8.7 Date doesn't respond to 'to_time'
+          Time.parse(date_string.to_s)
           
         end
 

--- a/lib/pith/plugins/publication/input.rb
+++ b/lib/pith/plugins/publication/input.rb
@@ -22,7 +22,16 @@ module Pith
         private
 
         def parse_date(date_string)
-          Time.parse(date_string) if date_string
+          
+          return unless date_string
+          
+          # yaml may parse the date for us, in which case
+          # we will be passed a Time or Date object
+          return date_string if date_string.instance_of? Time
+          return date_string.to_time if date_string.respond_to?('to_time')
+
+          Time.parse(date_string)
+          
         end
 
       end

--- a/spec/pith/plugins/publication_spec.rb
+++ b/spec/pith/plugins/publication_spec.rb
@@ -19,12 +19,12 @@ describe Pith::Plugins::Publication::TemplateMethods do
       @template.published_at.should == Time.local(1999, 12, 25, 22, 30)
     end
 
-    it "honours any parsing of time that yaml may do on the 'published' meta-field" do
-      @template.meta["published"] = Time.new(1999, 12, 25, 22, 30)
+    it "honours any parsing (of Time) that yaml may do on the 'published' meta-field" do
+      @template.meta["published"] = Time.local(1999, 12, 25, 22, 30)
       @template.published_at.should == Time.local(1999, 12, 25, 22, 30)
     end
 
-    it "honours any parsing of time that yaml may do on the 'published' meta-field" do
+    it "honours any parsing (to Date) of time that yaml may do on the 'published' meta-field" do
       @template.meta["published"] = Date.new(1999, 12, 25)
       @template.published_at.should == Time.local(1999, 12, 25)
     end

--- a/spec/pith/plugins/publication_spec.rb
+++ b/spec/pith/plugins/publication_spec.rb
@@ -19,6 +19,16 @@ describe Pith::Plugins::Publication::TemplateMethods do
       @template.published_at.should == Time.local(1999, 12, 25, 22, 30)
     end
 
+    it "honours any parsing of time that yaml may do on the 'published' meta-field" do
+      @template.meta["published"] = Time.new(1999, 12, 25, 22, 30)
+      @template.published_at.should == Time.local(1999, 12, 25, 22, 30)
+    end
+
+    it "honours any parsing of time that yaml may do on the 'published' meta-field" do
+      @template.meta["published"] = Date.new(1999, 12, 25)
+      @template.published_at.should == Time.local(1999, 12, 25)
+    end
+
   end
 
   describe "#updated_at" do
@@ -30,8 +40,13 @@ describe Pith::Plugins::Publication::TemplateMethods do
     
     it "can be overridden with an 'updated' meta-field" do
       @template.meta["published"] = "25 Dec 1999 22:30"
-      @template.meta["published"] = "1 Jan 2000 03:00"
+      @template.meta["updated"] = "1 Jan 2000 03:00"
       @template.updated_at.should == Time.local(2000, 1, 1, 3, 0)
+    end
+    
+    it "honours any parsing of time that yaml may do on the 'updated' meta-field" do
+      @template.meta["updated"] = Date.new(2000, 1, 1)
+      @template.updated_at.should == Time.local(2000, 1, 1)
     end
 
   end


### PR DESCRIPTION
**This fix assumes you're using the published plugin**

The issue i'm describing may be a ruby 2.0.0 thing (as this is what i'm using pith with most of the time)
I've found that if the published and updated files aren't wrapped as strings, YAML may parse the published and updated dates prior to assignment to the page meta data. 

This has tripped me up a few times, and may have tripped up others as well
## How to reproduce

Create a page where published date is not wrapped in strings.
This will raise an 'TypeError: no implicit conversion of Date into String'

```

---
published 2013-09-19
...

<h1>Hello world</h1>
```

Wrapping the date as a string will work

```

---
published '2013-09-19'
...

<h1>Hello world</h1>
```
